### PR TITLE
Lazy-load syntax validators on attr access

### DIFF
--- a/src/rfc3987_syntax/syntax_helpers.py
+++ b/src/rfc3987_syntax/syntax_helpers.py
@@ -1,3 +1,5 @@
+import sys
+
 from lark import Lark, ParseTree, exceptions
 
 from pathlib import Path
@@ -47,11 +49,9 @@ RFC3987_SYNTAX_TERMS: list[str] = [
 
 grammar: str = load_grammar(RFC3987_SYNTAX_GRAMMAR_PATH)
 
-syntax_parser = Lark(grammar, start=["iri", "iri_reference", "absolute_iri"], parser=RFC3987_SYNTAX_PARSER_TYPE)
-
 
 def parse(term: str, value: str) -> ParseTree:
-    return syntax_parser.parse(value, start=term)
+    return sys.modules[__name__].syntax_parser.parse(value, start=term)
 
 
 def is_valid_syntax(term: str, value: str):
@@ -76,7 +76,7 @@ def make_syntax_validator(rule_name):
 
 
 # Cache for lazily created validators
-_validator_cache = {}
+_attr_cache = {}
 
 
 SYNTAX_VALIDATOR_PREFIX = "is_valid_syntax_"
@@ -94,18 +94,27 @@ def get_syntax_validator(attr_name: str):
     return make_syntax_validator(term_name)
 
 
+def get_syntax_parser():
+    return Lark(grammar, start=["iri", "iri_reference", "absolute_iri"], parser=RFC3987_SYNTAX_PARSER_TYPE)
+
 def __getattr__(name):
     """
-    Lazily create syntax validators when accessed.
+    Lazily create attributes, in particular syntax validators, when accessed.
 
     When an attribute like 'is_valid_syntax_iri' is accessed, this function
     will create and cache the corresponding validator function.
+
+    We also create the syntax parser lazily.
     """
     try:
-        return _validator_cache[name]
+        return _attr_cache[name]
     except KeyError:
+        if name == 'syntax_parser':
+            syntax_parser = get_syntax_parser()
+            _attr_cache[name] = syntax_parser
+            return syntax_parser
         if validator := get_syntax_validator(name):
-            _validator_cache[name] = validator
+            _attr_cache[name] = validator
             return validator
 
     raise AttributeError(f"module '{__name__}' has no attribute '{name}'")

--- a/src/rfc3987_syntax/syntax_helpers.py
+++ b/src/rfc3987_syntax/syntax_helpers.py
@@ -75,78 +75,37 @@ def make_syntax_validator(rule_name):
     return syntax_validator
 
 
-is_valid_syntax_iri = make_syntax_validator("iri")
+# Cache for lazily created validators
+_validator_cache = {}
 
-is_valid_syntax_iri_reference = make_syntax_validator("iri_reference")
 
-is_valid_syntax_absolute_iri = make_syntax_validator("absolute_iri")
+SYNTAX_VALIDATOR_PREFIX = "is_valid_syntax_"
 
-is_valid_syntax_irelative_ref = make_syntax_validator("irelative_ref")
 
-is_valid_syntax_irelative_part = make_syntax_validator("irelative_part")
+def get_syntax_validator(attr_name: str):
+    if not attr_name.startswith(SYNTAX_VALIDATOR_PREFIX):
+        return None
 
-is_valid_syntax_ihier_part = make_syntax_validator("ihier_part")
+    term_name = attr_name[len(SYNTAX_VALIDATOR_PREFIX) :]
 
-is_valid_syntax_iauthority = make_syntax_validator("iauthority")
+    if term_name not in RFC3987_SYNTAX_TERMS:
+        return None
 
-is_valid_syntax_iuserinfo = make_syntax_validator("iuserinfo")
+    return make_syntax_validator(term_name)
 
-is_valid_syntax_ihost = make_syntax_validator("ihost")
 
-is_valid_syntax_ireg_name = make_syntax_validator("ireg_name")
+def __getattr__(name):
+    """
+    Lazily create syntax validators when accessed.
 
-is_valid_syntax_ipath = make_syntax_validator("ipath")
+    When an attribute like 'is_valid_syntax_iri' is accessed, this function
+    will create and cache the corresponding validator function.
+    """
+    try:
+        return _validator_cache[name]
+    except KeyError:
+        if validator := get_syntax_validator(name):
+            _validator_cache[name] = validator
+            return validator
 
-is_valid_syntax_ipath_abempty = make_syntax_validator("ipath_abempty")
-
-is_valid_syntax_ipath_absolute = make_syntax_validator("ipath_absolute")
-
-is_valid_syntax_ipath_noscheme = make_syntax_validator("ipath_noscheme")
-
-is_valid_syntax_ipath_rootless = make_syntax_validator("ipath_rootless")
-
-is_valid_syntax_ipath_empty = make_syntax_validator("ipath_empty")
-
-is_valid_syntax_isegment = make_syntax_validator("isegment")
-
-is_valid_syntax_isegment_nz = make_syntax_validator("isegment_nz")
-
-is_valid_syntax_isegment_nz_nc = make_syntax_validator("isegment_nz_nc")
-
-is_valid_syntax_ipchar = make_syntax_validator("ipchar")
-
-is_valid_syntax_iquery = make_syntax_validator("iquery")
-
-is_valid_syntax_ifragment = make_syntax_validator("ifragment")
-
-is_valid_syntax_iunreserved = make_syntax_validator("iunreserved")
-
-is_valid_syntax_ucschar = make_syntax_validator("ucschar")
-
-is_valid_syntax_iprivate = make_syntax_validator("iprivate")
-
-is_valid_syntax_sub_delims = make_syntax_validator("sub_delims")
-
-is_valid_syntax_ip_literal = make_syntax_validator("ip_literal")
-
-is_valid_syntax_ipvfuture = make_syntax_validator("ipvfuture")
-
-is_valid_syntax_ipv6address = make_syntax_validator("ipv6address")
-
-is_valid_syntax_h16 = make_syntax_validator("h16")
-
-is_valid_syntax_ls32 = make_syntax_validator("ls32")
-
-is_valid_syntax_ipv4address = make_syntax_validator("ipv4address")
-
-is_valid_syntax_dec_octet = make_syntax_validator("dec_octet")
-
-is_valid_syntax_unreserved = make_syntax_validator("unreserved")
-
-is_valid_syntax_alpha = make_syntax_validator("alpha")
-
-is_valid_syntax_digit = make_syntax_validator("digit")
-
-is_valid_syntax_hexdig = make_syntax_validator("hexdig")
-
-is_valid_syntax_port = make_syntax_validator("port")
+    raise AttributeError(f"module '{__name__}' has no attribute '{name}'")


### PR DESCRIPTION
Currently this module has quite a large import time (over 0.5 sec on my machine). 

This PR reduces this by lazy-loading the syntax validators lazily on attribute access.