### PR TITLE
Fix a typo in RFC3987_SYNTAX_TERMS

### DIFF
--- a/src/rfc3987_syntax/syntax_helpers.py
+++ b/src/rfc3987_syntax/syntax_helpers.py
@@ -12,7 +12,7 @@ RFC3987_SYNTAX_TERMS: list[str] = [
     "absolute_iri",
     "scheme",
     "irelative_ref",
-    "irelative_part"
+    "irelative_part",
     "ihier_part",
     "iauthority",
     "iuserinfo",


### PR DESCRIPTION
Noticed a typo